### PR TITLE
Fix main import to use IPRotator

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 # main.py
 import asyncio
 import logging
-from src.anonymity.ip_rotator import IpRotator
+from src.anonymity.ip_rotator import IPRotator
 from src.crawler.crawler import Crawler
 from src.profiler.tech_detector import TechDetector # Placeholder, will be implemented
 from src.attack_surface.analyzer import AttackSurfaceAnalyzer # Placeholder
@@ -47,7 +47,7 @@ async def main():
     logger.info(f"Starting HebbScan on target: {TARGET_URL}")
 
     # 1. Initialize IP Rotator
-    ip_rotator = IpRotator(
+    ip_rotator = IPRotator(
         proxy_list_path=PROXY_LIST_PATH,
         use_tor=USE_TOR,
         tor_port=TOR_SOCKS_PORT,


### PR DESCRIPTION
## Summary
- fix wrong IpRotator import in main.py

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d36b551348320ac8094d905210cdf