### PR TITLE
Fix f-string newline replacement

### DIFF
--- a/src/crawler/crawler.py
+++ b/src/crawler/crawler.py
@@ -80,7 +80,8 @@ class Crawler:
                 response.raise_for_status() # Raise an exception for HTTP errors (4xx or 5xx)
                 return response
         except httpx.HTTPStatusError as e:
-            logger.warning(f"HTTP error for {url}: {e.response.status_code} - {e.response.text[:100].replace('\n', ' ')}")
+            clean = e.response.text[:100].replace('\n', ' ')
+            logger.warning(f"HTTP error for {url}: {e.response.status_code} - {clean}")
             # Consider rotating IP on certain status codes like 403, 429
             if e.response.status_code in [403, 429, 503]: # Added 503 Service Unavailable
                 logger.warning(f"Detected potential block for {url}. Rotating IP.")

--- a/src/orchestrator/attack_orchestrator.py
+++ b/src/orchestrator/attack_orchestrator.py
@@ -79,7 +79,8 @@ class AttackOrchestrator:
                 response.raise_for_status() 
                 return response
         except httpx.HTTPStatusError as e:
-            logger.warning(f"HTTP error for {url} ({method}): {e.response.status_code} - {e.response.text[:100].replace('\n', ' ')}...")
+            clean = e.response.text[:100].replace('\n', ' ')
+            logger.warning(f"HTTP error for {url} ({method}): {e.response.status_code} - {clean}...")
             # Common blocking/error codes: 403 Forbidden, 429 Too Many Requests, 500 Internal Server Error
             if e.response.status_code in [403, 429]: 
                 logger.warning(f"Detected potential block for {url}. Rotating IP.")


### PR DESCRIPTION
## Summary
- fix f-string expression escaping in crawler and attack orchestrator

## Testing
- `python -m py_compile src/crawler/crawler.py src/orchestrator/attack_orchestrator.py`


------
https://chatgpt.com/codex/tasks/task_e_684d378672848320833c6e251ebe7d17