### PR TITLE
Fix __aexit__ signature in logic_flaws

### DIFF
--- a/src/vulnerabilities/logic_flaws.py
+++ b/src/vulnerabilities/logic_flaws.py
@@ -114,7 +114,8 @@ async def test_logic_flaws_vuln():
         async def get_proxies_for_request(self, force_tor=False):
             class AsyncProxyContext:
                 async def __aenter__(self): return None
-                async async def __aexit__(self, exc_type, exc_val, exc_tb): pass
+                async def __aexit__(self, exc_type, exc_val, exc_tb):
+                    pass
             return AsyncProxyContext(None)
         async def rotate_ip(self): pass
 


### PR DESCRIPTION
## Summary
- fix doubled `async` keyword in AsyncProxyContext

## Testing
- `python -m py_compile src/vulnerabilities/logic_flaws.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d38a3db6483209677ed5a7da201dc