### PR TITLE
Fix ASP.NET header detection rule

### DIFF
--- a/src/profiler/tech_detector.py
+++ b/src/profiler/tech_detector.py
@@ -66,7 +66,10 @@ class TechDetector:
                 "url": r"\.php"
             },
             "ASP.NET": {
-                "headers": {"x-aspnet-version": r".*|x-powered-by": r"ASP\.NET"},
+                "headers": {
+                    "x-aspnet-version": r".*",
+                    "x-powered-by": r"ASP\.NET"
+                },
                 "html": r"__VIEWSTATE"
             },
             "Node.js (Express)": {


### PR DESCRIPTION
## Summary
- separate header entries for ASP.NET detection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d398e92a4832098c0e2c286e89ffb